### PR TITLE
added a #define to optionally disable all the SDCard capabilities

### DIFF
--- a/t400/sd_log.cpp
+++ b/t400/sd_log.cpp
@@ -1,11 +1,18 @@
-#ifdef SDCARD
-#include <SdFat.h>
-#else
 #include "Arduino.h"  // for boolean type
-#endif
+
 
 #include "t400.h"
 #include "sd_log.h"
+
+// comment this next line out to disable ALL SD card functionality, but substantially free up nearly 8k of flash space.
+#define SDCARD 1
+//before 28656 - after 20396  = 8260
+
+
+#ifdef SDCARD
+#include <SdFat.h>
+#endif
+
 
 extern uint8_t temperatureUnit;
 

--- a/t400/sd_log.cpp
+++ b/t400/sd_log.cpp
@@ -1,4 +1,8 @@
+#ifdef SDCARD
 #include <SdFat.h>
+#else
+#include "Arduino.h"  // for boolean type
+#endif
 
 #include "t400.h"
 #include "sd_log.h"
@@ -7,8 +11,10 @@ extern uint8_t temperatureUnit;
 
 namespace sd {
 
+#ifdef SDCARD
 SdFat sd;
 SdFile file;
+#endif
 
 uint32_t syncTime      = 0;     // time of last sync(), in millis()
 
@@ -22,16 +28,18 @@ uint32_t syncTime      = 0;     // time of last sync(), in millis()
 
 void init() {
   close();
-  
+  #ifdef SDCARD
   if (!sd.begin(SD_CS, SPI_FULL_SPEED)) {
 //    error_P("card.init");
     return;
   }
+  #endif
 }
 
 bool open(char* fileName) {
   // Create LDxxxx.CSV for the lowest value of x.
-  
+
+  #ifdef SDCARD
   uint16_t i = 0;
   do {
     fileName[2] = (i/1000) % 10 + '0';
@@ -49,15 +57,18 @@ bool open(char* fileName) {
   }
   file.clearWriteError();
   
+  // write data header
+  file.print("time (s)");
+
+  #endif
+  
   Serial.print("v");
   Serial.println(FIRMWARE_VERSION);
 
   Serial.print("File: ");
   Serial.println(fileName);
 
-
   // write data header
-  file.print("time (s)");
   Serial.print("time (s)");
   
   /* We are no longer using the junction temperature in our data output.
@@ -82,47 +93,69 @@ bool open(char* fileName) {
   }*/
 
   for (uint8_t i = 0; i < SENSOR_COUNT; i++) {
+    #ifdef SDCARD
     file.print(", temp_");
     file.print(i, DEC);
+    #endif
     
     Serial.print(", temp_");
     Serial.print(i, DEC);
     
     switch(temperatureUnit) {
     case TEMPERATURE_UNITS_C:
+      #ifdef SDCARD
       file.print(" (C)");
+      #endif
       Serial.print(" (C)");
       break;
     case TEMPERATURE_UNITS_F:
+      #ifdef SDCARD
       file.print(" (F)");
+      #endif
       Serial.print(" (F)");
       break;
     case TEMPERATURE_UNITS_K:
+      #ifdef SDCARD
       file.print(" (K)");
+      #endif
       Serial.print(" (K)");
       break;
     }
   }
+  #ifdef SDCARD
   file.println();
   file.flush();
+  #endif
   Serial.println();
 
+  #ifdef SDCARD
   return (file.getWriteError() == false);
+  #else
+    return true;
+  #endif
 }
 
 void close() {
+  #ifdef SDCARD
   file.close();
+  #endif
 }
 
 bool log(char* message) {
   // TODO: Test if file is open first
   
   // log time to file
+  #ifdef SDCARD
   file.println(message);
+  #endif
 
   sync(false);
-  
+
+  #ifdef SDCARD
   return (file.getWriteError() == false);
+  #else
+    return true;
+  #endif
 }
 
 void sync(boolean force) {
@@ -135,7 +168,9 @@ void sync(boolean force) {
   }
   
   syncTime = millis();
+  #ifdef SDCARD
   file.flush();
+  #endif
 }
 
 } // namespace sd

--- a/t400/sd_log.cpp
+++ b/t400/sd_log.cpp
@@ -4,10 +4,6 @@
 #include "t400.h"
 #include "sd_log.h"
 
-// comment this next line out to disable ALL SD card functionality, but substantially free up nearly 8k of flash space.
-#define SDCARD 1
-//before 28656 - after 20396  = 8260
-
 
 #ifdef SDCARD
 #include <SdFat.h>

--- a/t400/t400.h
+++ b/t400/t400.h
@@ -64,5 +64,8 @@
 #define LCD_CS              A4
 #define LCD_BACKLIGHT_PIN   A5   // LCD backlight on pin
 
+// comment this next line out to disable ALL SD card functionality, but substantially free up nearly 8k of flash space.
+#define SDCARD 1
+
 
 #define LCD_CONTRAST     0x018*7  // Sets the LCD contrast

--- a/t400/t400.ino
+++ b/t400/t400.ino
@@ -22,7 +22,7 @@ Firmware for the Pax Instruments T400 temperature datalogger
 
 // comment this next line out to disable ALL SD card functionality, but substantially free up nearly 5k of flash space.
 #define SDCARD 1
-//before 28656 - after 23620  = 5036
+//before 28656 - after 20396  = 8260
 
 // Import libraries
 #include "t400.h"             // Board definitions
@@ -43,9 +43,7 @@ Firmware for the Pax Instruments T400 temperature datalogger
 #include "buttons.h"          // User buttons
 #include "typek_constant.h"   // Thermocouple calibration table
 #include "functions.h"        // Misc. functions
-#ifdef SDCARD
 #include "sd_log.h"           // SD card utilities
-#endif
 #define BUFF_MAX         80   // Size of the character buffer
 
 
@@ -144,10 +142,8 @@ void startLogging() {
     return;
   }
 
-  #ifdef SDCARD
   sd::init();
   logging = sd::open(fileName);
-  #endif
 }
 
 void stopLogging() {

--- a/t400/t400.ino
+++ b/t400/t400.ino
@@ -20,19 +20,12 @@ Firmware for the Pax Instruments T400 temperature datalogger
 
 */
 
-// comment this next line out to disable ALL SD card functionality, but substantially free up nearly 5k of flash space.
-#define SDCARD 1
-//before 28656 - after 20396  = 8260
 
 // Import libraries
 #include "t400.h"             // Board definitions
 
 #include <Wire.h>       // i2c
 #include <SPI.h>
-
-#ifdef SDCARD
-#include <SdFat.h>
-#endif
 
 #include "U8glib.h"     // LCD
 #include <MCP3424.h>    // ADC
@@ -46,12 +39,7 @@ Firmware for the Pax Instruments T400 temperature datalogger
 #include "sd_log.h"           // SD card utilities
 #define BUFF_MAX         80   // Size of the character buffer
 
-
-#ifdef SDCARD
 char fileName[] =        "LD0001.CSV";
-#else
-char fileName[] =        ""; // leave the variable for convenience, just empty it.
-#endif
 
 // MCP3424 for thermocouple measurements
 MCP3424      thermocoupleAdc(MCP3424_ADDR, MCP342X_GAIN_X8, MCP342X_16_BIT);  // address, gain, resolution
@@ -152,9 +140,7 @@ void stopLogging() {
   }
   
   logging = false;
-  #ifdef SDCARD
   sd::close();
-  #endif
 }
 
 static void readTemperatures() {
@@ -233,9 +219,7 @@ static void writeOutputs() {
   Serial.println(updateBuffer);
 
   if(logging) {
-    #ifdef SDCARD
     logging = sd::log(updateBuffer);
-    #endif
   }
 }
 

--- a/t400/t400.ino
+++ b/t400/t400.ino
@@ -20,12 +20,19 @@ Firmware for the Pax Instruments T400 temperature datalogger
 
 */
 
+// comment this next line out to disable ALL SD card functionality, but substantially free up nearly 5k of flash space.
+#define SDCARD 1
+//before 28656 - after 23620  = 5036
+
 // Import libraries
 #include "t400.h"             // Board definitions
 
 #include <Wire.h>       // i2c
 #include <SPI.h>
+
+#ifdef SDCARD
 #include <SdFat.h>
+#endif
 
 #include "U8glib.h"     // LCD
 #include <MCP3424.h>    // ADC
@@ -36,12 +43,17 @@ Firmware for the Pax Instruments T400 temperature datalogger
 #include "buttons.h"          // User buttons
 #include "typek_constant.h"   // Thermocouple calibration table
 #include "functions.h"        // Misc. functions
+#ifdef SDCARD
 #include "sd_log.h"           // SD card utilities
-
+#endif
 #define BUFF_MAX         80   // Size of the character buffer
 
 
+#ifdef SDCARD
 char fileName[] =        "LD0001.CSV";
+#else
+char fileName[] =        ""; // leave the variable for convenience, just empty it.
+#endif
 
 // MCP3424 for thermocouple measurements
 MCP3424      thermocoupleAdc(MCP3424_ADDR, MCP342X_GAIN_X8, MCP342X_16_BIT);  // address, gain, resolution
@@ -132,8 +144,10 @@ void startLogging() {
     return;
   }
 
+  #ifdef SDCARD
   sd::init();
   logging = sd::open(fileName);
+  #endif
 }
 
 void stopLogging() {
@@ -142,7 +156,9 @@ void stopLogging() {
   }
   
   logging = false;
+  #ifdef SDCARD
   sd::close();
+  #endif
 }
 
 static void readTemperatures() {
@@ -221,7 +237,9 @@ static void writeOutputs() {
   Serial.println(updateBuffer);
 
   if(logging) {
+    #ifdef SDCARD
     logging = sd::log(updateBuffer);
+    #endif
   }
 }
 


### PR DESCRIPTION
Frees up nearly 5K of flash space.
Used flash with the #define uncommented: 28656 , and with it commented out: 23620  giving a difference of: 5036