### PR TITLE
Performance improvements and 1/2 second sampling

### DIFF
--- a/t400/buttons.cpp
+++ b/t400/buttons.cpp
@@ -2,8 +2,6 @@
 #include "t400.h"
 #include <avr/sleep.h>
 
-namespace Buttons {
-
 uint8_t stuckButtonMask;
 uint8_t pendingButtons;
 
@@ -27,7 +25,7 @@ const uint8_t activeState[BUTTON_COUNT] = {
   HIGH,
 };
 
-void setup() {
+void setupButtons() {
 
   for(uint8_t b = 0; b < BUTTON_COUNT; b++) {
     if(activeState[b] == LOW) {
@@ -73,12 +71,12 @@ void buttonTask() {
 }
 
 
-bool pending() {
+bool buttonPending() {
   return (pendingButtons != 0);
 }
 
 // If a button was pressed, return it!
-uint8_t getPending() {
+uint8_t buttonGetPending() {
   uint8_t button = BUTTON_COUNT;
   
   noInterrupts();
@@ -96,8 +94,6 @@ uint8_t getPending() {
   return button;
 }
 
-} // namespace buttons
-
 // button interrupts
 ISR(INT6_vect) {
   // Workaround for the issue that ISR6 needs to be level sensitive to wake the processor from power down:
@@ -114,9 +110,9 @@ ISR(INT6_vect) {
     set_sleep_mode(SLEEP_MODE_PWR_DOWN);
   }
   
-  Buttons::buttonTask();
+  buttonTask();
   return;
 }
 
-ISR(INT3_vect) { Buttons::buttonTask();}
-ISR(PCINT0_vect) { Buttons::buttonTask();}
+ISR(INT3_vect) { buttonTask();}
+ISR(PCINT0_vect) { buttonTask();}

--- a/t400/buttons.h
+++ b/t400/buttons.h
@@ -14,11 +14,8 @@ enum Button {
     BUTTON_COUNT
 };
 
-namespace Buttons {
-
-  void setup();
-  bool pending();
-  uint8_t getPending();
-}
+void setupButtons();
+bool buttonPending();
+uint8_t buttonGetPending();
 
 #endif // BUTTONARRAY_HH

--- a/t400/functions.cpp
+++ b/t400/functions.cpp
@@ -346,8 +346,14 @@ void draw(
           u8g.drawStr(40, 15,fileName);
 
       // Interval
-      u8g.drawStr( 100, 15, printi(buf,logInterval));
-      u8g.drawStr(110, 15, "s");
+      if(logInterval==0)
+      {
+          u8g.drawStr( 100, 15, "500ms");
+      }else{
+          sprintf(buf,"%2d",logInterval);
+          u8g.drawStr( 103, 15, buf);
+          u8g.drawStr(113, 15, "s");
+      }
 
       // Draw battery
       switch(bStatus){

--- a/t400/functions.cpp
+++ b/t400/functions.cpp
@@ -9,7 +9,6 @@
 #include "t400.h"
 #include "functions.h"
 
-namespace Display {
 
 #define U8G_PAGE_HEIGHT     8
 
@@ -24,6 +23,9 @@ const uint8_t lines[LINE_COUNT][4] = {
     {65,  0,  65,   7}, // vline between TC2 and TC3
     {99,  0,  99,   7}, // vline between TC3 and TC4
 };
+
+// Function prototypes for t400.ino
+int16_t convertTemperatureInt(int16_t celcius);
 
 // Graphical LCD
 U8GLIB_PI13264  u8g(LCD_CS, LCD_A0, LCD_RST); // Use HW-SPI
@@ -118,6 +120,7 @@ void updateGraphScaling()
        p = *ptr;
        if(p!=OUT_OF_RANGE_INT)
        {
+           p = convertTemperatureInt(p);
            if(p>max) max = p;
            if(p<min) min = p;
        }
@@ -150,7 +153,7 @@ void updateGraphScaling()
   return;
 }
 
-void setup()
+void setupDisplay()
 {
   u8g.setContrast(LCD_CONTRAST);    // Set contrast level
   u8g.setRot180();                  // Rotate screen
@@ -202,8 +205,8 @@ void draw(
   char buf[8];
   uint8_t page = 0;
   uint8_t x;
-  uint8_t debug_point=0;
-  int16_t debug_point2=0;
+  //uint8_t debug_point=0;
+  //int16_t debug_point2=0;
   uint8_t num_points;
   uint8_t battX = 128;
   uint8_t battY = 9;
@@ -268,18 +271,25 @@ void draw(
         // Draw the temperature graph for each sensor
         for(uint8_t sensor = 0; sensor < 4; sensor++)
         {
+            int16_t tmp16;
+
             // if the sensor is out of range, don't show it. If we are showing one
             // channel, ignore the others
             if(temperatures[sensor] == OUT_OF_RANGE_INT || (sensor != graphChannel && graphChannel < 4) )
               continue;
 
+            tmp16 = convertTemperatureInt(graph[sensor][graphCurrentPoint]);
+
             // Get the position of the latest point
-            p = temperature_to_pixel(graph[sensor][graphCurrentPoint]);
+            //p = temperature_to_pixel(graph[sensor][graphCurrentPoint]);
+            p = temperature_to_pixel(tmp16);
+#if 0
             if(sensor==3)
             {
                 debug_point = p;
                 debug_point2 = graph[sensor][graphCurrentPoint];
             }
+#endif
 
             // Draw the channel number at the latest point
             u8g.drawStr(113+5*sensor, 3 + p, printi(buf,sensor+1));
@@ -288,7 +298,9 @@ void draw(
             index = graphCurrentPoint;
             for(uint8_t point = 0; point < num_points; point++)
             {
-                p = temperature_to_pixel(graph[sensor][index]);
+                tmp16 = convertTemperatureInt(graph[sensor][index]);
+                //p = temperature_to_pixel(graph[sensor][index]);
+                p = temperature_to_pixel(tmp16);
                 // Draw pixel at X, Y. X is # of pixels from the left
                 u8g.drawPixel(MAXIMUM_GRAPH_POINTS+12-point,p);
                 // Go to next pixel
@@ -427,8 +439,6 @@ void clear() {
 
   return;
 }
-
-} // End namespace Display
 
 
 // TODO: What namespace is this then?

--- a/t400/functions.h
+++ b/t400/functions.h
@@ -44,26 +44,22 @@ namespace Backlight {
 
 }
 
-namespace Display {
 
-  void resetGraph();
-  void updateGraphData(int16_t* temperatures);
-  void updateGraphScaling();
-  
-  void setup();
+void resetGraph();
+void updateGraphData(int16_t* temperatures);
+void updateGraphScaling();
 
-  void draw(
-    int16_t* temperatures,
-    uint8_t graphChannel,
-    uint8_t temperatureUnit,
-    char* fileName,
-    uint8_t logInterval,
-    ChargeStatus::State bStatus,
-    uint8_t batteryLevel
-    );
+void setupDisplay();
+
+void draw(int16_t* temperatures,
+        uint8_t graphChannel,
+        uint8_t temperatureUnit,
+        char* fileName,
+        uint8_t logInterval,
+        ChargeStatus::State bStatus,
+        uint8_t batteryLevel);
   
-  void clear();
-}
+void clear();
 
 // Converts the junction temperature into a voltage for offset
 // @param temperature reading from junction temperature sensor

--- a/t400/functions.h
+++ b/t400/functions.h
@@ -51,8 +51,7 @@ void updateGraphScaling();
 
 void setupDisplay();
 
-void draw(int16_t* temperatures,
-        uint8_t graphChannel,
+void draw(uint8_t graphChannel,
         uint8_t temperatureUnit,
         char* fileName,
         uint8_t logInterval,
@@ -69,7 +68,7 @@ int32_t celcius_to_microvolts(float jTemp);
 // Converts the thermocouple µV reading into some usable °C
 // @param microVolt reading from the ADC
 // @return Temperature, in ???
-float microvolts_to_celcius(int32_t microVolts);
+int16_t microvolts_to_celcius(int32_t microVolts);
 
 
 #endif

--- a/t400/t400.h
+++ b/t400/t400.h
@@ -15,7 +15,7 @@
 
 // Debugging
 #define DEBUG_JUNCTION_TEMPERATURE  0
-#define DEBUG_FAKE_DATA             1
+#define DEBUG_FAKE_DATA             0
 
 // Compile-time settings. Some of these should be set by the user during operation.
 #define SYNC_INTERVAL           1000       // millis between calls to sync()

--- a/t400/t400.h
+++ b/t400/t400.h
@@ -15,6 +15,7 @@
 
 // Debugging
 #define DEBUG_JUNCTION_TEMPERATURE  0
+#define DEBUG_FAKE_DATA             0
 
 // Compile-time settings. Some of these should be set by the user during operation.
 #define SYNC_INTERVAL           1000       // millis between calls to sync()

--- a/t400/t400.h
+++ b/t400/t400.h
@@ -15,13 +15,13 @@
 
 // Debugging
 #define DEBUG_JUNCTION_TEMPERATURE  0
-#define DEBUG_FAKE_DATA             0
+#define DEBUG_FAKE_DATA             1
 
 // Compile-time settings. Some of these should be set by the user during operation.
 #define SYNC_INTERVAL           1000       // millis between calls to sync()
 #define SENSOR_COUNT            4          // Number of sensors on the board (fixed)
 #define OUT_OF_RANGE_INT        32760      // Int value representing an invalid temp. measurement
-#define OUT_OF_RANGE            3276.0     // Double value representing an invalid temp. measurement
+//#define OUT_OF_RANGE            3276.0     // Double value representing an invalid temp. measurement
 
 // Graph display settings
 #define MAXIMUM_GRAPH_POINTS    100

--- a/t400/t400.ino
+++ b/t400/t400.ino
@@ -91,7 +91,7 @@ void rotateTemperatureUnit() {
   temperatureUnit = (temperatureUnit + 1) % TEMPERATURE_UNITS_COUNT;
 
   // Reset the graph so we don't have to worry about scaling it
-  Display::resetGraph();
+  //resetGraph();
 
   // TODO: Convert the current data to new units?
   return;
@@ -126,8 +126,8 @@ void setup(void) {
   Backlight::setup();
   Backlight::set(backlightEnabled);
 
-  Display::setup();
-  Display::resetGraph();
+  setupDisplay();
+  resetGraph();
 
   thermocoupleAdc.begin();
 
@@ -195,6 +195,7 @@ void fake_data(){
     temperatures_int[1] = (int16_t)tmpdbl+5.0;
     val += ADD;
     #endif
+
     #if 1
     static int16_t val=300;
     static int16_t step=5;
@@ -206,7 +207,7 @@ void fake_data(){
     if(val>=400 || val<= 200) step=step*-1;
     #endif
 
-#if 1
+#if 0
     temperatures_int[0] = convertTemperatureInt(temperatures_int[0]);
     temperatures_int[1] = convertTemperatureInt(temperatures_int[1]);
     temperatures_int[2] = convertTemperatureInt(temperatures_int[2]);
@@ -275,12 +276,14 @@ static void readTemperatures() {
 
     /******************* Float Math End ********************/
 
+#if 0
     // Now convert to C, F, K
     if(tmpint16 != OUT_OF_RANGE_INT)
     {
       //temperature = convertTemperature(temperature + ambient_float);
       tmpint16 = convertTemperatureInt(tmpint16);
     }
+#endif
 
     temperatures_int[m_channel_index] = tmpint16;
 
@@ -352,8 +355,8 @@ void loop() {
     writeOutputs();
 
     // Update some graph data.
-    Display::updateGraphData(temperatures_int);
-    Display::updateGraphScaling();
+    updateGraphData(temperatures_int);
+    updateGraphScaling();
 
     // Indicate we want to redraw the display
     refresh_display_flag = true;
@@ -367,7 +370,7 @@ void loop() {
     case BUTTON_POWER:
       // Disable power
       if(!logging) {
-        Display::clear();
+        clear();
         Backlight::set(0);
         Power::shutdown();
       }
@@ -394,7 +397,7 @@ void loop() {
         m_logInterval = (m_logInterval + 1) % LOG_INTERVAL_COUNT;
         resetTicks();
 
-        Display::resetGraph();  // Reset the graph, to keep the x axis consistent
+        resetGraph();  // Reset the graph, to keep the x axis consistent
         resetTicks();
         refresh_display_flag = true;
       }
@@ -443,7 +446,7 @@ void loop() {
     refresh_display_flag = false;
 
     // Actual draw of display, takes a bit of time
-    Display::draw(
+    draw(
       temperatures_int,
       graphChannel,
       temperatureUnit,

--- a/t400/t400.ino
+++ b/t400/t400.ino
@@ -169,6 +169,7 @@ void stopLogging() {
   return;
 }
 
+#if DEBUG_FAKE_DATA
 void fake_data(){
     // DEBUG: Fake some data
     #if 0
@@ -216,6 +217,7 @@ void fake_data(){
 
     return;
 }
+#endif
 
 uint8_t m_channel_index = SENSOR_COUNT;
 static void adc_start_next_conversion()
@@ -342,12 +344,15 @@ void loop() {
 
   // This locks in the samples into the array and does some other stuff. This
   // controls the sample rate of the data
-  if(m_sample_flag) {
+  if(m_sample_flag)
+  {
     m_sample_flag = false;
 
 
     // DEBUG, force fake values for testing
+    #if DEBUG_FAKE_DATA
     fake_data();
+    #endif
 
     //DS3231_get(&rtcTime);
 

--- a/t400/t400.ino
+++ b/t400/t400.ino
@@ -173,6 +173,11 @@ void stopLogging() {
 #if DEBUG_FAKE_DATA
 void fake_data(){
     // DEBUG: Fake some data
+
+    temperatures_int[0] = OUT_OF_RANGE_INT;
+    temperatures_int[1] = OUT_OF_RANGE_INT;
+    temperatures_int[2] = OUT_OF_RANGE_INT;
+    temperatures_int[3] = OUT_OF_RANGE_INT;
     #if 0
     // EXTREME!
     temperatures_int[0] = 30000; // 3270.9 C
@@ -203,8 +208,8 @@ void fake_data(){
     static int16_t step=5;
     temperatures_int[0] = val;
     temperatures_int[1] = val+50;
-    temperatures_int[2] = val+100;
-    temperatures_int[3] = val+150;
+    //temperatures_int[2] = val+100;
+    //temperatures_int[3] = val+150;
     val+=step;
     if(val>=400 || val<= 200) step=step*-1;
     #endif
@@ -277,7 +282,9 @@ static void readTemperatures()
 
     /******************* Float Math End ********************/
 
+    #if !DEBUG_FAKE_DATA
     temperatures_int[m_channel_index] = tmpint16;
+    #endif
 
     // We are done with this channel, kick off the next one
     adc_start_next_conversion();
@@ -370,6 +377,9 @@ void loop()
         clear();
         Backlight::set(0);
         Power::shutdown();
+      }else{
+        btn_disable_count = 3;
+        refresh_display_flag = true;
       }
       break;
 
@@ -396,8 +406,10 @@ void loop()
 
         resetGraph();  // Reset the graph, to keep the x axis consistent
         resetTicks();
-        refresh_display_flag = true;
+      }else{
+          btn_disable_count = 3;
       }
+      refresh_display_flag = true;
       break;
     case BUTTON_C:
       // Cycle temperature units
@@ -412,7 +424,8 @@ void loop()
     case BUTTON_D:
       // Sensor display mode
       graphChannel = (graphChannel + 1) % GRAPH_CHANNELS_COUNT;
-      while(graphChannel < 4 & temperatures_int[graphChannel] == OUT_OF_RANGE_INT) {
+      while( (graphChannel < SENSOR_COUNT) && (temperatures_int[graphChannel] == OUT_OF_RANGE_INT) )
+      {
         graphChannel = (graphChannel + 1) % GRAPH_CHANNELS_COUNT;
       }
       refresh_display_flag = true;


### PR DESCRIPTION
This branch changes how the t400 reads values, rather than read all 4 at one time we read as fast as we can which seems to be about 12 samples a second.  This decouples the readings from the rest of the system.  Adding in a 500ms timer kicked off when the 1Hz signal is received allows for 1/2 second sampling.  Also added logic to show a message to the user when buttons are disabled.

Sketch uses 28,390 bytes (99%) of program storage space. Maximum is 28,672 bytes.
Global variables use 2,306 bytes (90%) of dynamic memory, leaving 254 bytes for local variables. Maximum is 2,560 bytes.